### PR TITLE
Add hotfix bag capability

### DIFF
--- a/src/AllCardsBag.ttslua
+++ b/src/AllCardsBag.ttslua
@@ -62,7 +62,7 @@ function buildIndex()
   if (self.getData().ContainedObjects == nil) then
     return 1
   end
-  for i,cardData in ipairs(self.getData().ContainedObjects) do
+  for i, cardData in ipairs(self.getData().ContainedObjects) do
     local cardMetadata = JSON.decode(cardData.GMNotes)
     if (cardMetadata ~= nil) then
       addCardToIndex(cardData, cardMetadata)
@@ -71,9 +71,18 @@ function buildIndex()
       coroutine.yield(0)
     end
   end
-  for _, indexTable in pairs(classAndLevelIndex) do
-    table.sort(indexTable, cardComparator)
+  local hotfixBags = getObjectsWithTag("AllCardsHotfix")
+  for _, hotfixBag in ipairs(hotfixBags) do
+    if (#hotfixBag.getObjects() > 0) then
+      for i, cardData in ipairs(hotfixBag.getData().ContainedObjects) do
+        local cardMetadata = JSON.decode(cardData.GMNotes)
+        if (cardMetadata ~= nil) then
+          addCardToIndex(cardData, cardMetadata)
+        end
+      end
+    end
   end
+  buildSupplementalIndexes()
   indexingDone = true
   return 1
 end
@@ -82,69 +91,76 @@ end
 -- Param cardData: TTS object data for the card
 -- Param cardMetadata: SCED metadata for the card
 function addCardToIndex(cardData, cardMetadata)
-  -- Every card gets added to the ID index
   cardIdIndex[cardMetadata.id] = { data = cardData, metadata = cardMetadata }
   if (cardMetadata.alternate_ids ~= nil) then
     for _, alternateId in ipairs(cardMetadata.alternate_ids) do
       cardIdIndex[alternateId] = { data = cardData, metadata = cardMetadata }
     end
   end
+end
 
-  -- Add card to the basic weakness list, if appropriate.  Some weaknesses have
-  -- multiple copies, and are added multiple times
-  if (cardMetadata.weakness and cardMetadata.basicWeaknessCount ~= nil) then
-    for i = 1, cardMetadata.basicWeaknessCount do
-      table.insert(basicWeaknessList, cardMetadata.id)
+function buildSupplementalIndexes()
+  for cardId, card in pairs(cardIdIndex) do
+    local cardData = card.data
+    local cardMetadata = card.metadata
+    -- Add card to the basic weakness list, if appropriate.  Some weaknesses have
+    -- multiple copies, and are added multiple times
+    if (cardMetadata.weakness and cardMetadata.basicWeaknessCount ~= nil) then
+      for i = 1, cardMetadata.basicWeaknessCount do
+        table.insert(basicWeaknessList, cardMetadata.id)
+      end
+    end
+
+    -- Add the card to the appropriate class and level indexes
+    local isGuardian = false
+    local isSeeker = false
+    local isMystic = false
+    local isRogue = false
+    local isSurvivor = false
+    local isNeutral = false
+    local upgradeKey
+    if (cardMetadata.class ~= nil and cardMetadata.level ~= nil) then
+      isGuardian = string.match(cardMetadata.class, "Guardian")
+      isSeeker = string.match(cardMetadata.class, "Seeker")
+      isMystic = string.match(cardMetadata.class, "Mystic")
+      isRogue = string.match(cardMetadata.class, "Rogue")
+      isSurvivor = string.match(cardMetadata.class, "Survivor")
+      isNeutral = string.match(cardMetadata.class, "Neutral")
+      if (cardMetadata.level > 0) then
+        upgradeKey = "-upgrade"
+      else
+        upgradeKey = "-level0"
+      end
+      if (isGuardian) then
+        table.insert(classAndLevelIndex["Guardian"..upgradeKey], cardMetadata.id)
+      end
+      if (isSeeker) then
+        table.insert(classAndLevelIndex["Seeker"..upgradeKey], cardMetadata.id)
+      end
+      if (isMystic) then
+        table.insert(classAndLevelIndex["Mystic"..upgradeKey], cardMetadata.id)
+      end
+      if (isRogue) then
+        table.insert(classAndLevelIndex["Rogue"..upgradeKey], cardMetadata.id)
+      end
+      if (isSurvivor) then
+        table.insert(classAndLevelIndex["Survivor"..upgradeKey], cardMetadata.id)
+      end
+      if (isNeutral) then
+        table.insert(classAndLevelIndex["Neutral"..upgradeKey], cardMetadata.id)
+      end
     end
   end
-
-  -- Add the card to the appropriate class and level indexes
-  local isGuardian = false
-  local isSeeker = false
-  local isMystic = false
-  local isRogue = false
-  local isSurvivor = false
-  local isNeutral = false
-  local upgradeKey
-  if (cardMetadata.class == nil or cardMetadata.level == nil) then
-    -- If either class or level is missing, don't add this card to those indexes
-    return
-  end
-
-  isGuardian = string.match(cardMetadata.class, "Guardian")
-  isSeeker = string.match(cardMetadata.class, "Seeker")
-  isMystic = string.match(cardMetadata.class, "Mystic")
-  isRogue = string.match(cardMetadata.class, "Rogue")
-  isSurvivor = string.match(cardMetadata.class, "Survivor")
-  isNeutral = string.match(cardMetadata.class, "Neutral")
-  if (cardMetadata.level > 0) then
-    upgradeKey = "-upgrade"
-  else
-    upgradeKey = "-level0"
-  end
-  if (isGuardian) then
-    table.insert(classAndLevelIndex["Guardian"..upgradeKey], { data = cardData, metadata = cardMetadata })
-  end
-  if (isSeeker) then
-    table.insert(classAndLevelIndex["Seeker"..upgradeKey], { data = cardData, metadata = cardMetadata })
-  end
-  if (isMystic) then
-    table.insert(classAndLevelIndex["Mystic"..upgradeKey], { data = cardData, metadata = cardMetadata })
-  end
-  if (isRogue) then
-    table.insert(classAndLevelIndex["Rogue"..upgradeKey], { data = cardData, metadata = cardMetadata })
-  end
-  if (isSurvivor) then
-    table.insert(classAndLevelIndex["Survivor"..upgradeKey], { data = cardData, metadata = cardMetadata })
-  end
-  if (isNeutral) then
-    table.insert(classAndLevelIndex["Neutral"..upgradeKey], { data = cardData, metadata = cardMetadata })
+  for _, indexTable in pairs(classAndLevelIndex) do
+    table.sort(indexTable, cardComparator)
   end
 end
 
 -- Comparison function used to sort the class card bag indexes.  Sorts by card
 -- level, then name, then subname.
-function cardComparator(card1, card2)
+function cardComparator(id1, id2)
+  local card1 = cardIdIndex[id1]
+  local card2 = cardIdIndex[id2]
   if (card1.metadata.level ~= card2.metadata.level) then
     return card1.metadata.level < card2.metadata.level
   end
@@ -152,6 +168,10 @@ function cardComparator(card1, card2)
     return card1.data.Nickname < card2.data.Nickname
   end
   return card1.data.Description < card2.data.Description
+end
+
+function isIndexReady()
+  return indexingDone
 end
 
 -- Returns a specific card from the bag, based on ArkhamDB ID
@@ -199,7 +219,11 @@ end
 function getRandomWeaknessId()
   local pickedIndex = math.random(#basicWeaknessList)
   local weaknessId = basicWeaknessList[pickedIndex]
---  table.remove(basicWeaknessList, pickedIndex)
+  if (#basicWeaknessList > 1) then
+    table.remove(basicWeaknessList, pickedIndex)
+  else
+    broadcastToAll("All weaknesses have been drawn!", {0.9, 0.2, 0.2})
+  end
 
   return weaknessId
 end

--- a/src/ClassCardContainer.ttslua
+++ b/src/ClassCardContainer.ttslua
@@ -109,13 +109,14 @@ function buttonClick_place()
   assetCount = 0
   local allCardsBag = getObjectFromGUID(allCardsBagGuid)
   local cardList = allCardsBag.call("getCardsByClassAndLevel", {class = cardClass, upgraded = isUpgraded})
-  log("Got "..#cardList)
   placeCards(cardList)
 end
 
 -- Spawn all cards from the returned index
-function placeCards(cardList)
-  for _, card in ipairs(cardList) do
+function placeCards(cardIdList)
+  local allCardsBag = getObjectFromGUID(allCardsBagGuid)
+  for _, cardId in ipairs(cardIdList) do
+    local card = allCardsBag.call("getCardById", { id = cardId })
     placeCard(card.data, card.metadata)
   end
 end

--- a/src/LoaderUi.ttslua
+++ b/src/LoaderUi.ttslua
@@ -235,6 +235,14 @@ end
 function loadDecks()
   -- testLoadLotsOfDecks()
   -- Method in DeckImporterMain, visible due to inclusion
+
+  -- TODO: Make this use the configuration ID for the all cards bag
+  local allCardsBag = getObjectFromGUID("15bb07")
+  local indexReady = allCardsBag.call("isIndexReady")
+  if (not indexReady) then
+    broadcastToAll("Still loading player cards, please try again in a few seconds", {0.9, 0.2, 0.2})
+    return
+  end
   if (redDeckId ~= nil and redDeckId ~= "") then
     buildDeck("Red", redDeckId)
   end


### PR DESCRIPTION
The All Cards Bag will now look for other bags with a specific tag when 
building indexes, and overwrite the data in the main bag with any 
matching IDs from that bag.  This will allow easier hotfixing of data 
issues that arise.