### PR TITLE
Replace individual card spawning with deck spawning

### DIFF
--- a/src/DeckImporterMain.ttslua
+++ b/src/DeckImporterMain.ttslua
@@ -282,7 +282,7 @@ function loadCards(slots, playerColor, commandManager, configuration, command_co
       end
     end
 
-    -- Re-enable this later, as a command
+    -- TODO: Re-enable this later, as a command
     --handleAltInvestigatorCard(cardsToSpawn, "promo", configuration)
 
     table.sort(cardsToSpawn, cardComparator)
@@ -293,18 +293,38 @@ function loadCards(slots, playerColor, commandManager, configuration, command_co
     handleStartsInPlay(cardsToSpawn)
     handleAncestralKnowledge(cardsToSpawn)
 
-    for _, spawnCard in ipairs(cardsToSpawn) do
-      if (yPos[spawnCard.zone] == nil) then
-        yPos[spawnCard.zone] = 2
-      else
-        yPos[spawnCard.zone] = yPos[spawnCard.zone] + 0.2
+    -- Count the number of cards in each zone so we know if it's a deck or card.
+    -- TTS's Card vs. Deck distinction requires this since we can't spawn a deck
+    -- with only one card
+    local zoneCounts = getZoneCounts(cardsToSpawn)
+    local zoneDecks = { }
+    for zone, count in pairs(zoneCounts) do
+      if (count > 1) then
+        zoneDecks[zone] = buildDeckDataTemplate()
       end
-      local cardPos = Zones.getZonePosition(playerColor, spawnCard.zone)
-      cardPos.y = yPos[spawnCard.zone]
+    end
+    -- For each card in a deck zone, add it to that deck.  Otherwise, spawn it
+    -- directly
+    for _, spawnCard in ipairs(cardsToSpawn) do
+      if (zoneDecks[spawnCard.zone] ~= nil) then
+        addCardToDeck(zoneDecks[spawnCard.zone], spawnCard.data)
+      else
+        local cardPos = Zones.getZonePosition(playerColor, spawnCard.zone)
+        cardPos.y = 2
+        spawnObjectData({
+          data = spawnCard.data,
+          position = cardPos,
+          rotation = Zones.getDefaultCardRotation(playerColor, spawnCard.zone)})
+      end
+    end
+    -- Spawn each of the decks
+    for zone, deck in pairs(zoneDecks) do
+      local deckPos = Zones.getZonePosition(playerColor, zone)
+      deckPos.y = 3
       spawnObjectData({
-        data = spawnCard.data,
-        position = cardPos,
-        rotation = Zones.getDefaultCardRotation(playerColor, spawnCard.zone)})
+        data = deck,
+        position = deckPos,
+        rotation = Zones.getDefaultCardRotation(playerColor, zone)})
       coroutine.yield(0)
     end
 
@@ -339,6 +359,63 @@ function loadCards(slots, playerColor, commandManager, configuration, command_co
   startLuaCoroutine(self, "coinside")
 end
 
+-- Inserts a card into the given deck.  This does three things:
+--   1. Add the card's data to ContainedObjects
+--   2. Add the card's ID (the TTS CardID, not the Arkham ID) to the deck's
+--      ID list.  Note that the deck's ID list is "DeckIDs" even though it
+--      contains a list of card Ids
+--   3. Extract the card's CustomDeck table and add it to the deck.  The deck's
+--      "CustomDeck" field is a list of all CustomDecks used by cards within the
+--      deck, keyed by the DeckID and referencing the custom deck table
+-- Param deck: TTS deck data structure to add to
+-- Param card: Data for the card to be inserted
+function addCardToDeck(deck, cardData)
+  table.insert(deck.ContainedObjects, cardData)
+  table.insert(deck.DeckIDs, cardData.CardID)
+  for customDeckId, customDeckData in pairs(cardData.CustomDeck) do
+    deck.CustomDeck[customDeckId] = customDeckData
+  end
+end
+
+-- Count the number of cards in each zone
+-- Param cards: Table of {cardData, cardMetadata, zone}
+-- Return: Table of {zoneName=zoneCount}
+function getZoneCounts(cards)
+  local counts = { }
+  for _, card in ipairs(cards) do
+    if (counts[card.zone] == nil) then
+      counts[card.zone] = 1
+    else
+      counts[card.zone] = counts[card.zone] + 1
+    end
+  end
+
+  return counts
+end
+
+-- Create an empty deck data table which can have cards added to it.  This
+-- creates a new table on each call without using metatables or previous
+-- definitions because we can't be sure that TTS doesn't modify the structure
+-- Return: Table containing the minimal TTS deck data structure
+function buildDeckDataTemplate()
+  local deck = { }
+  deck.Name = "Deck"
+
+  -- Card data.  DeckIDs and CustomDeck entries will be built from the cards
+  deck.ContainedObjects = { }
+  deck.DeckIDs = { }
+  deck.CustomDeck = { }
+
+  -- Transform is required, Position and Rotation will be overridden by the
+  -- spawn call so can be omitted here
+  deck.Transform = {
+    scaleX = 1,
+    scaleY = 1,
+    scaleZ = 1, }
+
+  return deck
+end
+
 -- Get the PBN (Permanent/Bonded/Normal) value from the given metadata.
 -- Return: 1 for Permanent, 2 for Bonded, or 3 for Normal.  The actual values
 --     are irrelevant as they provide only grouping and the order between them
@@ -368,10 +445,17 @@ function cardComparator(card1, card2)
   if (pbn1 ~= pbn2) then
     return pbn1 > pbn2
   end
-  if (card1.data.Nickname ~= card2.data.Nickname) then
-    return card1.data.Nickname > card2.data.Nickname
+  if (pbn1 == 3) then
+    if (card1.data.Nickname ~= card2.data.Nickname) then
+      return card1.data.Nickname < card2.data.Nickname
+    end
+    return card1.data.Description < card2.data.Description
+  else
+    if (card1.data.Nickname ~= card2.data.Nickname) then
+      return card1.data.Nickname > card2.data.Nickname
+    end
+    return card1.data.Description > card2.data.Description
   end
-  return card1.data.Description > card2.data.Description
 end
 
 -- Replace the investigator card and minicard with an alternate version.  This


### PR DESCRIPTION
Rather than repeatedly spawning individual cards, the loader now creates 
a series of decks (one per zone) and spawns those decks as well.  This 
results in better performance and more reliable card ordering.